### PR TITLE
fix: constant case on windows and linux h sources

### DIFF
--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -143,6 +143,7 @@ void main() async {
               .replaceAll('my-plugin', '{{project_name.paramCase()}}')
               .replaceAll('MyPlugin', '{{project_name.pascalCase()}}')
               .replaceAll('myPlugin', '{{project_name.camelCase()}}')
+              .replaceAll('MY_PLUGIN', '{{project_name.constantCase()}}')
               .replaceAll(
                 'A very good Flutter federated plugin',
                 '{{{description}}}',


### PR DESCRIPTION
## Description

Some generated sources are leaking the "MY_PLUGIN" section from the template. Added support to replace it with `{{project_name.constantCase()}}` . 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
