### PR TITLE
feat: use hook to define current year for licenses and copyright headers

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,3 @@
 analyzer:
   exclude:
-    - brick/**
+    - brick/__brick__/**

--- a/brick/hooks/pre_gen.dart
+++ b/brick/hooks/pre_gen.dart
@@ -1,0 +1,5 @@
+import 'package:mason/mason.dart';
+
+void run(HookContext context) {
+  context.vars['current_year'] = DateTime.now().year;
+}

--- a/brick/hooks/pubspec.yaml
+++ b/brick/hooks/pubspec.yaml
@@ -1,0 +1,7 @@
+name: very_good_flutter_plugins_hooks
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  mason: ^0.1.0-dev

--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -52,9 +52,9 @@ final _targetMyPluginKtPath = path.join(
   '{{org_name.pathCase()}}',
   '{{project_name.pascalCase()}}Plugin.kt',
 );
-final year = DateTime.now().year;
+
 final copyrightHeader = '''
-// Copyright (c) $year, Very Good Ventures
+// Copyright (c) {{current_year}}, Very Good Ventures
 // https://verygood.ventures
 //
 // Use of this source code is governed by an MIT-style
@@ -152,6 +152,10 @@ void main() async {
               .replaceAll(
                 _pluginDependencies,
                 '{{> plugin_dependencies.dart }}',
+              )
+              .replaceAll(
+                'Copyright (c) 2022 Very Good Ventures',
+                'Copyright (c) {{current_year}} Very Good Ventures',
               )
           : contents;
       file = templatedContents is String


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Use mason hooks to set the copyright years to be generated upon brick usage, not creation. 

Closes #13

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
